### PR TITLE
Don't Appveyor with Julia 1.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 # Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
-    - julia_version: 1.0
     - julia_version: 1.4
     - julia_version: nightly
 platform:


### PR DESCRIPTION
AppVeyor fails at the moment for two reasons: (1) the `_jll`s in the manifest can't be used in <1.3 I believe, and (2) Hydrogen anyway requires at least 1.2. This makes it consistent with Travis (only test on 1.4 and nightly).